### PR TITLE
add `minVersion` to requirement

### DIFF
--- a/src/commonMain/kotlin/de/voize/semver4k/Requirement.kt
+++ b/src/commonMain/kotlin/de/voize/semver4k/Requirement.kt
@@ -101,7 +101,7 @@ class Requirement
         minver = null
 
         val ranges = mutableListOf<Range?>()
-        this.getAllAllRanges(this, ranges)
+        this.getAllGreaterOrEqualRanges(this, ranges)
 
         for (range in ranges) {
             if (range == null) {
@@ -131,12 +131,17 @@ class Requirement
         return null
     }
 
-    private fun getAllAllRanges(requirement: Requirement?, res: MutableList<Range?>): List<Range?> {
+    private fun getAllGreaterOrEqualRanges(requirement: Requirement?, res: MutableList<Range?>): List<Range?> {
         if (requirement!!.range != null) {
-            res.add(requirement.range)
+            if (requirement.range!!.op.equals(RangeOperator.GT)
+                || requirement.range.op.equals(RangeOperator.GTE)
+                || requirement.range.op.equals(RangeOperator.EQ)
+            ) {
+                res.add(requirement.range)
+            }
         } else {
-            getAllAllRanges(requirement.req1, res)
-            getAllAllRanges(requirement.req2, res)
+            getAllGreaterOrEqualRanges(requirement.req1, res)
+            getAllGreaterOrEqualRanges(requirement.req2, res)
         }
 
         return res

--- a/src/commonMain/kotlin/de/voize/semver4k/Requirement.kt
+++ b/src/commonMain/kotlin/de/voize/semver4k/Requirement.kt
@@ -1,8 +1,8 @@
 package de.voize.semver4k
 
-import de.voize.semver4k.Range.RangeOperator
-import de.voize.semver4k.Semver.SemverType
 import de.voize.semver4k.Tokenizer.tokenize
+import de.voize.semver4k.Semver.SemverType
+import de.voize.semver4k.Range.RangeOperator
 
 /**
  * A requirement will provide an easy way to check if a version is satisfying.
@@ -68,9 +68,8 @@ class Requirement
                         if (range.version.suffixTokens?.isNotEmpty() == true) {
                             val allowed = range.version
                             if (version.major == allowed.major &&
-                                version.minor == allowed.minor &&
-                                version.patch == allowed.patch
-                            ) {
+                                    version.minor == allowed.minor &&
+                                    version.patch == allowed.patch) {
                                 return true
                             }
                         }
@@ -190,21 +189,21 @@ class Requirement
         private val IVY_DYNAMIC_MINOR_PATTERN = Regex("(\\d+)\\.\\+")
         private val IVY_LATEST_PATTERN = Regex("latest\\.\\w+")
         private val IVY_MATH_BOUNDED_PATTERN = Regex(
-            "(\\[|\\])" +  // 1ST GROUP: a square bracket
-                    "([\\d\\.]+)" +  // 2ND GROUP: a version
-                    "," +  // a comma separator
-                    "([\\d\\.]+)" +  // 3RD GROUP: a version
-                    "(\\[|\\])" // 4TH GROUP: a square bracket
+                "(\\[|\\])" +  // 1ST GROUP: a square bracket
+                        "([\\d\\.]+)" +  // 2ND GROUP: a version
+                        "," +  // a comma separator
+                        "([\\d\\.]+)" +  // 3RD GROUP: a version
+                        "(\\[|\\])" // 4TH GROUP: a square bracket
         )
         private val IVY_MATH_LOWER_UNBOUNDED_PATTERN = Regex(
-            "\\(," +  // a parenthesis and a comma separator
-                    "([\\d\\.]+)" +  // 1ST GROUP: a version
-                    "(\\[|\\])" // 2ND GROUP: a square bracket
+                "\\(," +  // a parenthesis and a comma separator
+                        "([\\d\\.]+)" +  // 1ST GROUP: a version
+                        "(\\[|\\])" // 2ND GROUP: a square bracket
         )
         private val IVY_MATH_UPPER_UNBOUNDED_PATTERN = Regex(
-            "(\\[|\\])" +  // 1ST GROUP: a square bracket
-                    "([\\d\\.]+)" +  // 2ND GROUP: a version
-                    ",\\)" // a comma separator and a parenthesis
+                "(\\[|\\])" +  // 1ST GROUP: a square bracket
+                        "([\\d\\.]+)" +  // 2ND GROUP: a version
+                        ",\\)" // a comma separator and a parenthesis
         )
 
         /**
@@ -296,8 +295,7 @@ class Requirement
                 val major = matchPath.groupValues[1].toInt()
                 val minor = matchPath.groupValues[2].toInt()
                 val lower = Requirement(Range("$major.$minor.0", RangeOperator.GTE), null, null, null)
-                val upper =
-                    Requirement(Range(major.toString() + "." + (minor + 1) + ".0", RangeOperator.LT), null, null, null)
+                val upper = Requirement(Range(major.toString() + "." + (minor + 1) + ".0", RangeOperator.LT), null, null, null)
                 return Requirement(null, lower, RequirementOperator.AND, upper)
             }
             val matchMinor = IVY_DYNAMIC_MINOR_PATTERN.find(requirement)
@@ -616,11 +614,11 @@ class Requirement
          */
         private fun extrapolateVersion(semver: Semver): Semver {
             val sb = StringBuilder()
-                .append(semver.major)
-                .append(".")
-                .append(if (semver.minor == null) 0 else semver.minor)
-                .append(".")
-                .append(if (semver.patch == null) 0 else semver.patch)
+                    .append(semver.major)
+                    .append(".")
+                    .append(if (semver.minor == null) 0 else semver.minor)
+                    .append(".")
+                    .append(if (semver.patch == null) 0 else semver.patch)
             var first = true
             for (i in 0 until (semver.suffixTokens?.size ?: 0)) {
                 if (first) {

--- a/src/commonMain/kotlin/de/voize/semver4k/Semver.kt
+++ b/src/commonMain/kotlin/de/voize/semver4k/Semver.kt
@@ -470,6 +470,23 @@ class Semver @JvmOverloads constructor(val originalValue: String, val type: Semv
         return with(major!!, minor!!, patch!! + 1, false, false)
     }
 
+    fun nextIncrement(): Semver {
+        if (suffixTokens == null || suffixTokens.isEmpty()) {
+            if (patch != null) {
+                return withIncPatch()
+            }
+
+            if (minor != null) {
+                return create(type, major!!, minor!!.plus(1), null, null, build);
+            }
+                return create(type, major!!.plus(1), null, null, null, build);
+
+        }
+
+        val suffixes = suffixTokens.joinToString(separator = ".")
+        return withSuffix(suffixes + ".0")
+    }
+
     private fun with(major: Int, minor: Int, patch: Int, suffix: Boolean, build: Boolean): Semver {
         val tempMinor: Int? = if (this.minor != null) minor else null
         val tempPatch: Int? = if (this.patch != null) patch else null

--- a/src/commonMain/kotlin/de/voize/semver4k/Semver.kt
+++ b/src/commonMain/kotlin/de/voize/semver4k/Semver.kt
@@ -477,14 +477,21 @@ class Semver @JvmOverloads constructor(val originalValue: String, val type: Semv
             }
 
             if (minor != null) {
-                return create(type, major!!, minor!!.plus(1), null, null, build);
+                return create(type, major!!, minor!!.plus(1), null, null, build)
             }
-                return create(type, major!!.plus(1), null, null, null, build);
 
+            return create(type, major!!.plus(1), null, null, null, build)
         }
 
-        val suffixes = suffixTokens.joinToString(separator = ".")
-        return withSuffix(suffixes + ".0")
+        if (suffixTokens.size > 1 && suffixTokens.last() != null && suffixTokens.last()!!.toIntOrNull() != null) {
+            val suffixes = suffixTokens.sliceArray(IntRange(0, suffixTokens.size - 2)).joinToString(separator = ".")
+            val last = suffixTokens.last()!!.toInt() + 1
+
+            return withSuffix("$suffixes.$last")
+        } else {
+            val suffixes = suffixTokens.joinToString(separator = ".")
+            return withSuffix("$suffixes.0")
+        }
     }
 
     private fun with(major: Int, minor: Int, patch: Int, suffix: Boolean, build: Boolean): Semver {

--- a/src/jvmTest/kotlin/de/voize/semver4k/SemverTest.kt
+++ b/src/jvmTest/kotlin/de/voize/semver4k/SemverTest.kt
@@ -361,6 +361,54 @@ class SemverTest {
         Assert.assertFalse(Semver("0.1.2").isStable)
     }
 
+    @Test
+    fun findsNextIncrements() {
+        Assert.assertEquals(Semver("1.0.1"), Semver("1.0.0").nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.0"), Semver("1.0.0-beta").nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5"), Semver("1.0.0-beta.4").nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5+sha899-d8g79f87"), Semver("1.0.0-beta.4+sha899-d8g79f87").nextIncrement())
+    }
+
+    @Test
+    fun findsNextIncrements_loose() {
+        Assert.assertEquals(Semver("2", SemverType.LOOSE), Semver("1", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("1.2", SemverType.LOOSE), Semver("1.1", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("1.0.1", SemverType.LOOSE), Semver("1.0.0", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.LOOSE), Semver("1.0.0-beta", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.LOOSE), Semver("1.0.0-beta.4", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5+sha899-d8g79f87", SemverType.LOOSE), Semver("1.0.0-beta.4+sha899-d8g79f87", SemverType.LOOSE).nextIncrement())
+    }
+
+    @Test
+    fun findsNextIncrements_npm() {
+        Assert.assertEquals(Semver("2", SemverType.NPM), Semver("1", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("1.2", SemverType.NPM), Semver("1.1", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("1.0.1", SemverType.NPM), Semver("1.0.0", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.NPM), Semver("1.0.0-beta", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.NPM), Semver("1.0.0-beta.4", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5+sha899-d8g79f87", SemverType.NPM), Semver("1.0.0-beta.4+sha899-d8g79f87", SemverType.NPM).nextIncrement())
+    }
+
+    @Test
+    fun findsNextIncrements_ivy() {
+        Assert.assertEquals(Semver("2", SemverType.IVY), Semver("1", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("1.2", SemverType.IVY), Semver("1.1", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("1.0.1", SemverType.IVY), Semver("1.0.0", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.IVY), Semver("1.0.0-beta", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.IVY), Semver("1.0.0-beta.4", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5+sha899-d8g79f87", SemverType.IVY), Semver("1.0.0-beta.4+sha899-d8g79f87", SemverType.IVY).nextIncrement())
+    }
+
+    @Test
+    fun findsNextIncrements_cocoapods() {
+        Assert.assertEquals(Semver("2", SemverType.COCOAPODS), Semver("1", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("1.2", SemverType.COCOAPODS), Semver("1.1", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("1.0.1", SemverType.COCOAPODS), Semver("1.0.0", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.COCOAPODS), Semver("1.0.0-beta", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.COCOAPODS), Semver("1.0.0-beta.4", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("1.0.0-beta.5+sha899-d8g79f87", SemverType.COCOAPODS), Semver("1.0.0-beta.4+sha899-d8g79f87", SemverType.COCOAPODS).nextIncrement())
+    }
+
     companion object {
         private fun assertIsSemver(semver: Semver, value: String, major: Int, minor: Int?, patch: Int?, suffixTokens: Array<String>, build: String) {
             Assert.assertEquals(value, semver.value)

--- a/src/jvmTest/kotlin/de/voize/semver4k/SemverTest.kt
+++ b/src/jvmTest/kotlin/de/voize/semver4k/SemverTest.kt
@@ -363,6 +363,7 @@ class SemverTest {
 
     @Test
     fun findsNextIncrements() {
+        Assert.assertEquals(Semver("0.1.1"), Semver("0.1.0").nextIncrement())
         Assert.assertEquals(Semver("1.0.1"), Semver("1.0.0").nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.0"), Semver("1.0.0-beta").nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.5"), Semver("1.0.0-beta.4").nextIncrement())
@@ -373,6 +374,7 @@ class SemverTest {
     fun findsNextIncrements_loose() {
         Assert.assertEquals(Semver("2", SemverType.LOOSE), Semver("1", SemverType.LOOSE).nextIncrement())
         Assert.assertEquals(Semver("1.2", SemverType.LOOSE), Semver("1.1", SemverType.LOOSE).nextIncrement())
+        Assert.assertEquals(Semver("0.1.1", SemverType.LOOSE), Semver("0.1.0", SemverType.LOOSE).nextIncrement())
         Assert.assertEquals(Semver("1.0.1", SemverType.LOOSE), Semver("1.0.0", SemverType.LOOSE).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.LOOSE), Semver("1.0.0-beta", SemverType.LOOSE).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.LOOSE), Semver("1.0.0-beta.4", SemverType.LOOSE).nextIncrement())
@@ -383,6 +385,7 @@ class SemverTest {
     fun findsNextIncrements_npm() {
         Assert.assertEquals(Semver("2", SemverType.NPM), Semver("1", SemverType.NPM).nextIncrement())
         Assert.assertEquals(Semver("1.2", SemverType.NPM), Semver("1.1", SemverType.NPM).nextIncrement())
+        Assert.assertEquals(Semver("0.1.1", SemverType.NPM), Semver("0.1.0", SemverType.NPM).nextIncrement())
         Assert.assertEquals(Semver("1.0.1", SemverType.NPM), Semver("1.0.0", SemverType.NPM).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.NPM), Semver("1.0.0-beta", SemverType.NPM).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.NPM), Semver("1.0.0-beta.4", SemverType.NPM).nextIncrement())
@@ -393,6 +396,7 @@ class SemverTest {
     fun findsNextIncrements_ivy() {
         Assert.assertEquals(Semver("2", SemverType.IVY), Semver("1", SemverType.IVY).nextIncrement())
         Assert.assertEquals(Semver("1.2", SemverType.IVY), Semver("1.1", SemverType.IVY).nextIncrement())
+        Assert.assertEquals(Semver("0.1.1", SemverType.IVY), Semver("0.1.0", SemverType.IVY).nextIncrement())
         Assert.assertEquals(Semver("1.0.1", SemverType.IVY), Semver("1.0.0", SemverType.IVY).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.IVY), Semver("1.0.0-beta", SemverType.IVY).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.IVY), Semver("1.0.0-beta.4", SemverType.IVY).nextIncrement())
@@ -403,6 +407,7 @@ class SemverTest {
     fun findsNextIncrements_cocoapods() {
         Assert.assertEquals(Semver("2", SemverType.COCOAPODS), Semver("1", SemverType.COCOAPODS).nextIncrement())
         Assert.assertEquals(Semver("1.2", SemverType.COCOAPODS), Semver("1.1", SemverType.COCOAPODS).nextIncrement())
+        Assert.assertEquals(Semver("0.1.1", SemverType.COCOAPODS), Semver("0.1.0", SemverType.COCOAPODS).nextIncrement())
         Assert.assertEquals(Semver("1.0.1", SemverType.COCOAPODS), Semver("1.0.0", SemverType.COCOAPODS).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.0", SemverType.COCOAPODS), Semver("1.0.0-beta", SemverType.COCOAPODS).nextIncrement())
         Assert.assertEquals(Semver("1.0.0-beta.5", SemverType.COCOAPODS), Semver("1.0.0-beta.4", SemverType.COCOAPODS).nextIncrement())

--- a/src/jvmTest/kotlin/de/voize/semver4k/TokenizerTest.kt
+++ b/src/jvmTest/kotlin/de/voize/semver4k/TokenizerTest.kt
@@ -91,32 +91,25 @@ class TokenizerTest {
     fun tokenize_NPM_suffix() {
         val requirement = "1.2.7-rc.1"
         val tokens = Tokenizer.tokenize(requirement, Semver.SemverType.NPM)
-        Assert.assertEquals(3, tokens.size.toLong())
-        Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[0]?.type)
-        Assert.assertEquals("1.2.7", tokens[0]?.value)
 
-        // @TODO: Differentiate between hyphen for range vs. suffix
-        Assert.assertEquals(Tokenizer.TokenType.HYPHEN, tokens[1]?.type)
-        Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[2]?.type)
-        Assert.assertEquals("rc.1", tokens[2]?.value)
+        // in NPM, A range can only be considered when `-` is surrounded by spaces
+        // Since the - is directly next to the version it's automatically
+        // considered as part of the version
+        Assert.assertEquals(1, tokens.size.toLong())
+        Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[0]?.type)
+        Assert.assertEquals("1.2.7-rc.1", tokens[0]?.value)
     }
 
     @Test
     fun tokenize_NPM_or_suffix() {
         val requirement = "1.2.7-rc.1 || 1.2.7-rc.2"
         val tokens = Tokenizer.tokenize(requirement, Semver.SemverType.NPM)
-        Assert.assertEquals(7, tokens.size.toLong())
+        Assert.assertEquals(3, tokens.size.toLong())
         Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[0]?.type)
-        Assert.assertEquals("1.2.7", tokens[0]?.value)
-        Assert.assertEquals(Tokenizer.TokenType.HYPHEN, tokens[1]?.type)
+        Assert.assertEquals("1.2.7-rc.1", tokens[0]?.value)
+        Assert.assertEquals(Tokenizer.TokenType.OR, tokens[1]?.type)
         Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[2]?.type)
-        Assert.assertEquals("rc.1", tokens[2]?.value)
-        Assert.assertEquals(Tokenizer.TokenType.OR, tokens[3]?.type)
-        Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[4]?.type)
-        Assert.assertEquals("1.2.7", tokens[4]?.value)
-        Assert.assertEquals(Tokenizer.TokenType.HYPHEN, tokens[5]?.type)
-        Assert.assertEquals(Tokenizer.TokenType.VERSION, tokens[6]?.type)
-        Assert.assertEquals("rc.2", tokens[6]?.value)
+        Assert.assertEquals("1.2.7-rc.2", tokens[2]?.value)
     }
 
     @Test


### PR DESCRIPTION
Hi,

as mentioned in #1 this PR adds a new method to `Requirement` that allows to request for the minimum version that fullfills a requirement.

All tests from the nodejs version were added to the test suite

Three changes were needed to get it to pass correctly:
1) The addition of the `minVersion` method to `Requirement`
2) The addition of a `nextIncrement` method to `Semver` that allows to add the smallest increment possible to a version
   - if a version is simply 1.0.0 it will happily increment to 1.0.1
   - if a version is 1.0 it will increment to 1.1
   - if a version is 1 it will increment to 2
   - suffixes are also taken in account might need some improvements though
 3) The tokenizer treated "-" as a hyphen (as in version ranges) in all cases, though the NPM ranges spec mentions that a hyphen must have a space before and after to be valid, the change adds this behaviour to the tokenizer

Best regards,
Stéphane